### PR TITLE
Add package.exs to submit to hex.pm

### DIFF
--- a/package.exs
+++ b/package.exs
@@ -1,0 +1,17 @@
+defmodule IDNA.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :idna,
+     version: "1.0.0",
+     description: "A pure Erlang IDNA implementation",
+     package: package]
+  end
+
+  defp package do
+    [files: ~w(src priv ebin Makefile Emakefile README.md License.txt),
+     contributors: ["Benoit Chesneau", "Tim Fletcher"],
+     licenses: ["MIT"],
+     links: [{"GitHub", "https://github.com/benoitc/erlang-idna/"}]]
+  end
+end


### PR DESCRIPTION
(Now on the right branch)

I added contributors based on GitHub contributors and the license looks like it's MIT

Considering that you have Elixir (0.15.0 last stable), you need to:

$ mix local.hex
$ mix hex.user register
$ mix hex.publish

This should be enough to publish idna as a package to hex.pm
