### PR TITLE
Recommend `unicode` over `xmerl` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A pure Erlang IDNA implementation.
 ## Usage
 
 ```erlang
-1> Domain = xmerl_ucs:from_utf8("www.詹姆斯.com").
+1> Domain = unicode.characters_to_list("www.詹姆斯.com").
 ...
 2> idna:to_ascii(Domain).
 ...


### PR DESCRIPTION
In [publicsuffix-elixir](https://github.com/seomoz/publicsuffix-elixir), I used the code from the `Usage` section in your README.  A user reported problems with `xmerl` and has opened seomoz/publicsuffix-elixir#23 to change our code to use `unicode.characters_to_list/1` instead of `xmerl_ucs.from_utf8/1`.

However, I have very little familiarity with the erlang ecosystem (since I use Elixir as my main language, not Erlang) and even less familiarity with these libraries.  Is there any reason I should not switch to using the `unicode` function?  Does it make sense for your README to recommend it as well?