### PR TITLE
specify source for unicode_util_compat

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {erl_opts, []}.
 
-{deps, [{unicode_util_compat, "0.2.0"}]}.
+{deps, [{unicode_util_compat, "0.2.0", {git, "https://github.com/benoitc/unicode_util_compat"}}]}.
 
 {minimum_otp_vsn, "18.0"}.


### PR DESCRIPTION
Source for unicode_util_compat shall be specified in rebar.conf for rebar to be able to 
fetch this dependency.
