### PR TITLE
Fixed bug with middle dot context

### DIFF
--- a/src/idna_context.erl
+++ b/src/idna_context.erl
@@ -79,7 +79,7 @@ valid_contexto(CP, Label, Pos) ->
       % MIDDLE DOT
       if
         (Pos > 0) andalso (Pos < (Len -1)) ->
-          case lists:sublist(Label, Pos, Pos +2) of
+          case lists:sublist(Label, Pos, 3) of
             [16#006C, _, 16#006C] -> true;
             _ -> false
           end;

--- a/test/idna_test.erl
+++ b/test/idna_test.erl
@@ -201,6 +201,8 @@ valid_contexto_test() ->
   false = idna_context:valid_contexto(Latin_l ++ Latin_middle_dot, 0),
   false = idna_context:valid_contexto(Latin_middle_dot, 0),
   false = idna_context:valid_contexto(Latin_l ++ Latin_middle_dot ++ Latin, 1),
+  true = idna_context:valid_contexto("ru" ++ Latin_l ++ Latin_middle_dot ++  Latin_l ++ "z", 3),
+  false = idna_context:valid_contexto("ru" ++ Latin ++ Latin_middle_dot ++  Latin_l ++ "z", 3),
 
   % RFC 5892 Rule A.4 (Greek Lower Numeral Sign)
   Glns = [16#0375],


### PR DESCRIPTION
erlang sublist takes (list, position, number of characters after)

> lists:sublist([1,2,3,4], 2, 2).
[2,3]
> lists:sublist([1,2,3,4], 2, 5).
[2,3,4]

previously would only match on l · l and not lists that contained it